### PR TITLE
Add extra validation to adding methods and properties

### DIFF
--- a/src/Base.def.js
+++ b/src/Base.def.js
@@ -25,6 +25,28 @@
         },
 
         /**
+         * Checks whether properties of `expr` are *all* non functions.
+         * @param {object} expr
+         */
+        hasNoFunctions: function (expr) {
+            var methodNames,
+                i;
+
+            if (!this.isObject(expr)) {
+                return true;
+            }
+
+            methodNames = Object.keys(expr);
+            for (i = 0; i < methodNames.length; i++) {
+                if (this.isFunctionOptional(expr[methodNames[i]])) {
+                    return false;
+                }
+            }
+
+            return true;
+        },
+
+        /**
          * Verifies if `expr` is a Giant class.
          * @param {$oop.Base} expr
          */


### PR DESCRIPTION
Hi @danstocker 

We have a bit of a problem at the moment with developers using the wrong methods when constructing classes. Often they are using `addPublic()` instead of `addMethods()`. We're also seeing private methods being added to the public spaces.

This PR tightens up the validation to help prevent some of these cases.
