### PR TITLE
Fix addPrivate for undefined properties

### DIFF
--- a/src/Base.def.js
+++ b/src/Base.def.js
@@ -38,7 +38,7 @@
 
             methodNames = Object.keys(expr);
             for (i = 0; i < methodNames.length; i++) {
-                if (this.isFunctionOptional(expr[methodNames[i]])) {
+                if (this.isFunction(expr[methodNames[i]])) {
                     return false;
                 }
             }

--- a/src/Properties.def.js
+++ b/src/Properties.def.js
@@ -151,7 +151,7 @@
          * Adds single value property to the context.
          * @this {$oop.Base}
          * @param {string} propertyName Property name.
-         * @param value {*} Property value to be assigned.
+         * @param {*} value Property value to be assigned.
          * @param {boolean} [isWritable]
          * @param {boolean} [isEnumerable]
          * @param {boolean} [isConfigurable]


### PR DESCRIPTION
the following code fails without this fix

`
.addPrivate({
    _foo: undefined
})
`